### PR TITLE
Add `log_usage`.

### DIFF
--- a/dsp/modules/aws_models.py
+++ b/dsp/modules/aws_models.py
@@ -244,12 +244,22 @@ class AWSAnthropic(AWSModel):
             },
         ]
         return (n, query_args)
+    
+    def log_usage(self, response):
+        response_header = response["ResponseMetadata"]["HTTPHeaders"]
+        input_token_size = response_header["x-amzn-bedrock-input-token-count"]
+        output_token_size = response_header["x-amzn-bedrock-output-token-count"]
+        total_token_size = int(input_token_size) + int(output_token_size)
+        print(f"Anthropic Input Token Response Usage: {input_token_size}")
+        print(f"Anthropic Output Token Response Usage: {output_token_size}")
+        print(f"Anthropic Total Token Response Usage: {total_token_size}")
 
     def _call_model(self, body: str) -> str:
         response = self.aws_provider.predictor.invoke_model(
             modelId=self._model_name,
             body=body,
         )
+        self.log_usage(response)
         response_body = json.loads(response["body"].read())
         return response_body["content"][0]["text"]
 

--- a/dsp/modules/aws_models.py
+++ b/dsp/modules/aws_models.py
@@ -247,12 +247,12 @@ class AWSAnthropic(AWSModel):
     
     def log_usage(self, response):
         response_header = response["ResponseMetadata"]["HTTPHeaders"]
-        input_token_size = response_header["x-amzn-bedrock-input-token-count"]
-        output_token_size = response_header["x-amzn-bedrock-output-token-count"]
-        total_token_size = int(input_token_size) + int(output_token_size)
-        print(f"Anthropic Input Token Response Usage: {input_token_size}")
-        print(f"Anthropic Output Token Response Usage: {output_token_size}")
-        print(f"Anthropic Total Token Response Usage: {total_token_size}")
+        input_token_size = int(response_header["x-amzn-bedrock-input-token-count"])
+        output_token_size = int(response_header["x-amzn-bedrock-output-token-count"])
+        total_token_size = input_token_size + output_token_size
+        logging.info("Anthropic Input Token Usage: %d", input_token_size)
+        logging.info("Anthropic Response Token Usage: %d", output_token_size)
+        logging.info("Anthropic Total Token Usage: %d", total_token_size)
 
     def _call_model(self, body: str) -> str:
         response = self.aws_provider.predictor.invoke_model(


### PR DESCRIPTION
Implement the `log_usage` function for the current use of `aws_model`.

Due to the version update, some adjustments are necessary to ensure compatibility with version 2.6.

At present, version 2.5 is a better option for our project because of the model's location. I will explore how to specify the location in version 2.6.